### PR TITLE
(01.09) 최종 수정 - 주식추천 병합 완료, 긍부정 기사 수정

### DIFF
--- a/investment_survey/settings.py
+++ b/investment_survey/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     'survey',
     'news_analyzer',
+    'stock',
 ]
 
 MIDDLEWARE = [

--- a/investment_survey/urls.py
+++ b/investment_survey/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('', include('survey.urls')),
     path('news/', include('news_analyzer.urls')),  # news_analyzer의 URL 연결
+    path('stock/', include('stock.urls')),
 ]

--- a/survey/templates/survey/hot_topic.html
+++ b/survey/templates/survey/hot_topic.html
@@ -9,18 +9,12 @@
         <div class="hot-topic-box-wrapper">
             <!-- Left Boxes: Good News -->
             <div class="hot-topic-box">
-                <h2 class="hot-topic-title good-news">금일 호재</h2>
-                <p class="hot-topic-content">
-                    {{ main_positive_news.title|truncatechars:50 }}
-                </p>
+                <h2 class="hot-topic-title good-news">금일 긍정 뉴스</h2>
             </div>
 
             <!-- Right Boxes: Bad News -->
             <div class="hot-topic-box">
-                <h2 class="hot-topic-title bad-news">금일 악재</h2>
-                <p class="hot-topic-content">
-                    {{ main_negative_news.title|truncatechars:50 }}
-                </p>
+                <h2 class="hot-topic-title bad-news">금일 부정 뉴스</h2>
             </div>
         </div>
 

--- a/survey/urls.py
+++ b/survey/urls.py
@@ -19,9 +19,6 @@ urlpatterns = [
     path('mbti_test/', views.mbti_test, name='mbti_test'),
     path('mbti_result/', views.mbti_result, name='mbti_result'),
 
-    # 주식 추천
-    path('stock_recommendations/', views.stock_recommendations, name='stock_recommendations'),
-
     # News 경로
     path('News_home/', views.News_home, name='News_home'),
     path('hot_topic/', views.hot_topic, name='hot_topic'),

--- a/survey/views.py
+++ b/survey/views.py
@@ -24,7 +24,6 @@ def index_view(request):
     return render(request, 'survey/index.html')
 
 
-
 # 로그인 & 로그아웃
 def signup_view(request):
     if request.method == 'POST':
@@ -37,11 +36,10 @@ def signup_view(request):
         form = UserCreationForm()
     return render(request, 'survey/signup.html', {'form': form})
 
+
 def logout_view(request):
     logout(request)
     return redirect('News_home')
-
-
 
 
 # 마이페이지
@@ -79,12 +77,6 @@ def mypage_view(request):
     }
 
     return render(request, 'survey/mypage.html', context)
-
-
-# 주식 추천
-@login_required
-def stock_recommendations(request):
-    return render(request, 'survey/stock_recommendations.html')
 
 
 # News
@@ -173,8 +165,6 @@ def hot_topic(request):
 
         positive_news = []
         negative_news = []
-        main_positive_news = None
-        main_negative_news = None
 
         # 뉴스 분류
         for title, content, url in news_data:
@@ -188,30 +178,13 @@ def hot_topic(request):
                 'url': url
             }
 
+            # 긍정/부정 점수에 따라 뉴스 분류
             if pos_score > neg_score:
-                if not main_positive_news:  # 첫 번째 긍정 뉴스를 메인 뉴스로
-                    main_positive_news = news_item
-                elif len(positive_news) < 4:  # 나머지는 목록에
+                if len(positive_news) < 4:  # 최대 4개까지만 저장
                     positive_news.append(news_item)
             elif neg_score > pos_score:
-                if not main_negative_news:  # 첫 번째 부정 뉴스를 메인 뉴스로
-                    main_negative_news = news_item
-                elif len(negative_news) < 4:  # 나머지는 목록에
+                if len(negative_news) < 4:  # 최대 4개까지만 저장
                     negative_news.append(news_item)
-
-        # 부족한 기사 채우기
-        if not main_positive_news:
-            main_positive_news = {
-                'title': '오늘은 주요 호재가 없습니다',
-                'content': '현재 시장에 주요한 호재성 뉴스가 없습니다.',
-                'url': '#'
-            }
-        if not main_negative_news:
-            main_negative_news = {
-                'title': '오늘은 주요 악재가 없습니다',
-                'content': '현재 시장에 주요한 악재성 뉴스가 없습니다.',
-                'url': '#'
-            }
 
         while len(positive_news) < 4:
             positive_news.append({
@@ -227,8 +200,6 @@ def hot_topic(request):
             })
 
         context = {
-            'main_positive_news': main_positive_news,
-            'main_negative_news': main_negative_news,
             'positive_news': positive_news,
             'negative_news': negative_news,
         }
@@ -241,8 +212,6 @@ def hot_topic(request):
             'url': '#'
         }
         context = {
-            'main_positive_news': default_item,
-            'main_negative_news': default_item,
             'positive_news': [default_item] * 4,
             'negative_news': [default_item] * 4
         }


### PR DESCRIPTION
# 수정 사항

## 1. 호재/악재 기사
    - 호재->긍정 / 악재->부정으로 용어 변경
    - 타이틀 아래 뜨던 기사 삭제
   
## 2. 주식 추천 연결
    - survey/views.py, survey/urls.py에 있던 주식 추천 항목 삭제
    - investment_survey/settings.py, investment_survey/urls.py에 주식 추천 url 입력 